### PR TITLE
eliminated deprecation notice

### DIFF
--- a/src/IsbnFormatterExtension.php
+++ b/src/IsbnFormatterExtension.php
@@ -11,7 +11,7 @@ use Twig\TwigFilter;
 
 class IsbnFormatterExtension extends AbstractExtension
 {
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('formatIsbn', [$this, 'formatIsbn']),


### PR DESCRIPTION
eliminated deprecation notice: 
"Method "Twig\Extension\ExtensionInterface::getFilters()" might add "array" as a native return type declaration in the future. Do the same in implementation "NicoHaase\TwigIsbnFormatter\IsbnFormatterExtension" now to avoid errors or add an explicit @return annotation to suppress this message."

(Shown in Symfony Profiler e.g. with Symfony v.6.4.3)